### PR TITLE
Create an endpoint for renaming a repository

### DIFF
--- a/cmd/omegaup-gitserver/auth.go
+++ b/cmd/omegaup-gitserver/auth.go
@@ -49,6 +49,7 @@ type omegaupAuthorization struct {
 type authorizationProblemResponse struct {
 	Status    string `json:"status"`
 	HasSolved bool   `json:"has_solved"`
+	IsSystem  bool   `json:"is_system"`
 	IsAdmin   bool   `json:"is_admin"`
 	CanView   bool   `json:"can_view"`
 	CanEdit   bool   `json:"can_edit"`
@@ -328,6 +329,7 @@ func (a *omegaupAuthorization) authorize(
 	requestContext.Request.Username = username
 	if username == "omegaup:system" || *insecureSkipAuthorization {
 		// This is the frontend, and we trust it completely.
+		requestContext.Request.IsSystem = true
 		requestContext.Request.IsAdmin = true
 		requestContext.Request.CanView = true
 		requestContext.Request.CanEdit = true

--- a/cmd/omegaup-gitserver/main.go
+++ b/cmd/omegaup-gitserver/main.go
@@ -87,10 +87,11 @@ func muxHandler(
 }
 
 func (h *muxGitHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	splitPath := strings.SplitN(r.URL.Path[1:], "/", 2)
+	splitPath := strings.Split(r.URL.Path[1:], "/")
 	if len(splitPath) >= 1 && splitPath[0] == "metrics" {
 		h.metricsHandler.ServeHTTP(w, r)
-	} else if len(splitPath) == 2 && splitPath[1] == "git-upload-zip" {
+	} else if len(splitPath) == 2 && splitPath[1] == "git-upload-zip" ||
+		len(splitPath) == 3 && splitPath[1] == "rename-repository" {
 		h.zipHandler.ServeHTTP(w, r)
 	} else {
 		h.gitHandler.ServeHTTP(w, r)

--- a/handler_test.go
+++ b/handler_test.go
@@ -32,6 +32,7 @@ const (
 	userAuthorization     = "Basic dXNlcjp1c2Vy"
 	editorAuthorization   = "Basic ZWRpdG9yOmVkaXRvcg=="
 	adminAuthorization    = "Basic YWRtaW46YWRtaW4="
+	systemAuthorization   = "OmegaUpSharedSecret secret-token omegaup:system"
 	readonlyAuthorization = "Basic cmVhZG9ubHk6cmVhZG9ubHk="
 )
 
@@ -49,6 +50,17 @@ func authorize(
 	repositoryName string,
 	operation githttp.GitOperation,
 ) (githttp.AuthorizationLevel, string) {
+	if r.Header.Get("Authorization") == systemAuthorization {
+		requestContext := request.FromContext(ctx)
+		requestContext.Request.Username = "omegaup:system"
+		requestContext.Request.ProblemName = repositoryName
+		requestContext.Request.IsSystem = true
+		requestContext.Request.IsAdmin = true
+		requestContext.Request.CanView = true
+		requestContext.Request.CanEdit = true
+		return githttp.AuthorizationAllowed, "omegaup:system"
+	}
+
 	username, _, ok := r.BasicAuth()
 	if !ok {
 		w.Header().Set("WWW-Authenticate", "Basic realm=\"Git\"")

--- a/request/request.go
+++ b/request/request.go
@@ -17,6 +17,7 @@ type Request struct {
 	ProblemName string
 	Username    string
 	Create      bool
+	IsSystem    bool
 	IsAdmin     bool
 	CanView     bool
 	CanEdit     bool


### PR DESCRIPTION
This change allows the frontend to rename a repository. This is needed
because when creating a problem, the metadata for it needs to be
committed into the database before sending out the request to gitserver,
and if this happens to fail, there is no way to undo this operation.

Instead, now the workflow will be create the repository with a random
name, and only if everything is ready to be committed, rename it to the
correct name, in a sort of two-phase commit.