### PR TITLE
Perform better validation on filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         go:
-          - 1.13
           - 1.14
     name: Go ${{ matrix.go }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.13
+          go-version: 1.14
         id: go
 
       - name: Install git2go

--- a/handler.go
+++ b/handler.go
@@ -123,7 +123,7 @@ var (
 			PathRegexps: []*regexp.Regexp{
 				regexp.MustCompile("^.gitattributes$"),
 				regexp.MustCompile("^.gitignore$"),
-				regexp.MustCompile("^statements(/[^/]+\\.(markdown|gif|jpe?g|png|svg))?$"),
+				regexp.MustCompile("^statements(/[^/]+\\.(md|markdown|gif|jpe?g|png|svg))?$"),
 				regexp.MustCompile("^examples(/[^/]+\\.(in|out))?$"),
 				regexp.MustCompile("^interactive/Main\\.distrib\\.[a-z0-9]+$"),
 				regexp.MustCompile("^interactive/examples(/[^/]+\\.(in|out))?$"),
@@ -134,7 +134,7 @@ var (
 		{
 			ReferenceName: "refs/heads/protected",
 			PathRegexps: []*regexp.Regexp{
-				regexp.MustCompile("^solutions(/[^/]+\\.(markdown|gif|jpe?g|png|svg|py|cpp|c|java|kp|kj))?$"),
+				regexp.MustCompile("^solutions(/[^/]+\\.(md|markdown|gif|jpe?g|png|svg|py|cpp|c|java|kp|kj))?$"),
 				regexp.MustCompile("^tests(/.*)?$"),
 			},
 		},


### PR DESCRIPTION
This change adds two new validations on the ziphandler:

* It ensures that cases are not contained within nested directories.
* It throws out any files that wouldn't be recognized by the regular
  handler.