### PR TITLE
Uprev omegaup/go-base to v2

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/inconshreveable/log15"
 	git "github.com/lhchavez/git2go/v32"
 	"github.com/omegaup/githttp"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -345,7 +345,7 @@ func pushToSubdirectory(remote *url.URL) error {
 
 func main() {
 	flag.Parse()
-	log = base.StderrLog()
+	log = base.StderrLog(false)
 
 	if *commitHash == "" {
 		panic(errors.New("Must provide a -commit flag"))

--- a/cmd/omegaup-gitserver/auth_test.go
+++ b/cmd/omegaup-gitserver/auth_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"encoding/base64"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"golang.org/x/crypto/ed25519"
 	"testing"
 )
@@ -25,7 +25,7 @@ func TestVerifyArgon2idHash(t *testing.T) {
 }
 
 func TestParseBearerAuth(t *testing.T) {
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	keyBytes, err := base64.StdEncoding.DecodeString(DefaultConfig().Gitserver.PublicKey)
 	if err != nil {
 		t.Fatalf("failed to parse shared key: %v", err)

--- a/cmd/omegaup-gitserver/config.go
+++ b/cmd/omegaup-gitserver/config.go
@@ -15,6 +15,7 @@ type DbConfig struct {
 type LoggingConfig struct {
 	File  string
 	Level string
+	JSON  bool
 }
 
 // GitserverConfig represents the configuration for the Grader.

--- a/cmd/omegaup-gitserver/main.go
+++ b/cmd/omegaup-gitserver/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 var (
@@ -120,14 +120,22 @@ func main() {
 
 	if config.Logging.File != "" {
 		var err error
-		if log, err = base.RotatingLog(config.Logging.File, config.Logging.Level); err != nil {
+		log, err = base.RotatingLog(
+			config.Logging.File,
+			config.Logging.Level,
+			config.Logging.JSON,
+		)
+		if err != nil {
 			panic(err)
 		}
 	} else if config.Logging.Level == "debug" {
-		log = base.StderrLog()
+		log = base.StderrLog(config.Logging.JSON)
 	} else {
 		log = log15.New()
-		log.SetHandler(base.ErrorCallerStackHandler(log15.LvlInfo, log15.StderrHandler))
+		log.SetHandler(base.ErrorCallerStackHandler(
+			log15.LvlInfo,
+			base.StderrHandler(config.Logging.JSON),
+		))
 	}
 
 	if config.Gitserver.RootPath == "" {

--- a/cmd/omegaup-translate-problem/main.go
+++ b/cmd/omegaup-translate-problem/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/pkg/errors"
 )
 
@@ -602,7 +602,7 @@ func main() {
 	defer git.Shutdown()
 
 	flag.Parse()
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	args := flag.Args()
 	if len(args) != 3 {

--- a/cmd/omegaup-translate-problem/main_test.go
+++ b/cmd/omegaup-translate-problem/main_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 func TestRoundtrip(t *testing.T) {
@@ -19,7 +19,7 @@ func TestRoundtrip(t *testing.T) {
 		defer os.RemoveAll(dirName)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	mergedPath := path.Join(dirName, "merged")
 	unmergedPath := path.Join(dirName, "unmerged")

--- a/cmd/omegaup-update-problem/main.go
+++ b/cmd/omegaup-update-problem/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 	"github.com/pkg/errors"
 )
@@ -343,7 +343,7 @@ func commitBlobs(
 
 func main() {
 	flag.Parse()
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	if *author == "" {
 		log.Crit("author cannot be empty. Please specify one with -author")

--- a/cmd/omegaup-update-problem/main_test.go
+++ b/cmd/omegaup-update-problem/main_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver"
 	"github.com/omegaup/gitserver/gitservertest"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 func getTreeOid(t *testing.T, extraFileContents map[string]io.Reader, log log15.Logger) *git.Oid {
@@ -88,7 +88,7 @@ func getTreeOid(t *testing.T, extraFileContents map[string]io.Reader, log log15.
 }
 
 func TestIdenticalTrees(t *testing.T) {
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	defaultSettingsTree := getTreeOid(t, map[string]io.Reader{}, log)
 
@@ -192,7 +192,7 @@ func validateReferences(
 }
 
 func TestProblemUpdateZip(t *testing.T) {
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	tmpdir, err := ioutil.TempDir("", "gitrepo")
 	if err != nil {
@@ -325,7 +325,7 @@ func TestProblemUpdateZip(t *testing.T) {
 }
 
 func TestProblemUpdateBlobs(t *testing.T) {
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	tmpdir, err := ioutil.TempDir("", "gitrepo")
 	if err != nil {

--- a/cmd/packfileparser/main.go
+++ b/cmd/packfileparser/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/inconshreveable/log15"
 	git "github.com/lhchavez/git2go/v32"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 var (
@@ -125,7 +125,7 @@ func processObject(repository *git.Repository, oid *git.Oid, message string) err
 
 func main() {
 	flag.Parse()
-	log = base.StderrLog()
+	log = base.StderrLog(false)
 
 	var repository *git.Repository
 	var odb *git.Odb

--- a/go.mod
+++ b/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/lhchavez/git2go/v32 v32.0.0-prerelease.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
 	github.com/o1egl/paseto v1.0.0
-	github.com/omegaup/githttp v1.2.0
-	github.com/omegaup/go-base v1.0.1
-	github.com/omegaup/quark v1.3.0
+	github.com/omegaup/githttp v1.3.0
+	github.com/omegaup/go-base/v2 v2.0.0
+	github.com/omegaup/quark v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca

--- a/go.sum
+++ b/go.sum
@@ -229,12 +229,12 @@ github.com/o1egl/paseto v1.0.0/go.mod h1:5HxsZPmw/3RI2pAwGo1HhOOwSdvBpcuVzO7uDkm
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/omegaup/githttp v1.2.0 h1:zasZzEqtnwbieDgg9AkYs8EuG6sGhk07rERBptwjXP8=
-github.com/omegaup/githttp v1.2.0/go.mod h1:/89tj4YBkX5XRmwWWB4WWE96gtc52/d4zq273eVWll0=
-github.com/omegaup/go-base v1.0.1 h1:7771a0jnJm4CPuK2lJxb56w03ASM1BkYLLfnYwhPagA=
-github.com/omegaup/go-base v1.0.1/go.mod h1:KRWOUExqxHkr/h1GiHEtAKGp4rx6mOGWsBSlN636INY=
-github.com/omegaup/quark v1.3.0 h1:+Y1rHkrxXSVmg2F4l1c2nGriutUCL8F1FcqSSdPn7aQ=
-github.com/omegaup/quark v1.3.0/go.mod h1:ZwBiK+RsbUUO3EVWR90+6WlYU5peSVUHg1sDGK+RiQY=
+github.com/omegaup/githttp v1.3.0 h1:Oz5QuCKZ9Nvo3Q4O7yHolP/IDg85TKYrxoSf5ZuZSLI=
+github.com/omegaup/githttp v1.3.0/go.mod h1:+zgLa30wqP55TVUZTrF6z+zWsFnx+zR3uJ/gs+1hm9k=
+github.com/omegaup/go-base/v2 v2.0.0 h1:A4TGNKDbbAiF55EfxPh5r8knS/zDpFFJpFCYerqByzE=
+github.com/omegaup/go-base/v2 v2.0.0/go.mod h1:k5PYTZcULZt7Dbx67WI0Wk3WHJSMmyadEG1aWx6YbVg=
+github.com/omegaup/quark v1.4.0 h1:0eR/b9zgY9cGlyuGrKZhkGEBVVy3Qk+oCmlJn/ed3Ns=
+github.com/omegaup/quark v1.4.0/go.mod h1:Wfdxag9uBCOveCQvMr63VBSZUyEn7xLBfVrtePKaVrs=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -457,8 +457,6 @@ google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMt
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
-google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=
 google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/handler.go
+++ b/handler.go
@@ -22,7 +22,7 @@ import (
 	git "github.com/lhchavez/git2go/v32"
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 	"github.com/pkg/errors"
 )

--- a/handler_test.go
+++ b/handler_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver/gitservertest"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 )
 
@@ -288,7 +288,7 @@ func TestInvalidRef(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, false, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -360,7 +360,7 @@ func TestDelete(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, false, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -435,7 +435,7 @@ func TestServerCreateReview(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, false, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -1224,7 +1224,7 @@ func TestPushGitbomb(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, false, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -1341,7 +1341,7 @@ func TestConfig(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, false, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -1688,7 +1688,7 @@ func TestInteractive(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(
@@ -1857,7 +1857,7 @@ func TestExampleCases(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -2182,7 +2182,7 @@ func TestStatements(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -2276,7 +2276,7 @@ func TestTests(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(GitHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),

--- a/metrics.go
+++ b/metrics.go
@@ -3,7 +3,7 @@ package gitserver
 import (
 	"net/http"
 
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/request/request.go
+++ b/request/request.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 )
 
 type key int

--- a/ziphandler.go
+++ b/ziphandler.go
@@ -24,7 +24,7 @@ import (
 	git "github.com/lhchavez/git2go/v32"
 	"github.com/omegaup/githttp"
 	"github.com/omegaup/gitserver/request"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 	"github.com/pkg/errors"
 )

--- a/ziphandler_test.go
+++ b/ziphandler_test.go
@@ -20,7 +20,7 @@ import (
 
 	git "github.com/lhchavez/git2go/v32"
 	"github.com/omegaup/gitserver/gitservertest"
-	base "github.com/omegaup/go-base"
+	base "github.com/omegaup/go-base/v2"
 	"github.com/omegaup/quark/common"
 )
 
@@ -121,7 +121,7 @@ func TestPushZip(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(ZipHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -202,7 +202,7 @@ func TestConvertZip(t *testing.T) {
 	}
 	defer repo.Free()
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	fileContents := map[string]string{
 		".gitignore":             defaultGitfiles[".gitignore"],
@@ -282,7 +282,7 @@ func TestZiphandlerStatements(t *testing.T) {
 	}
 	defer repo.Free()
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	for idx, testcase := range []struct {
 		name          string
@@ -371,7 +371,7 @@ func TestTestplan(t *testing.T) {
 	}
 	defer repo.Free()
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 
 	for testplanContents, expectedError := range map[string]string{
 		"0 0.0.0.0":        "invalid-testplan: invalid weight '0.0.0.0': strconv.ParseFloat: parsing \"0.0.0.0\": invalid syntax",
@@ -439,7 +439,7 @@ func TestUpdateProblemSettings(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(ZipHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -574,7 +574,7 @@ func TestUpdateProblemSettingsWithCustomValidator(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(ZipHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
@@ -820,7 +820,7 @@ func TestRenameProblem(t *testing.T) {
 		defer os.RemoveAll(tmpDir)
 	}
 
-	log := base.StderrLog()
+	log := base.StderrLog(false)
 	ts := httptest.NewServer(ZipHandler(
 		tmpDir,
 		NewGitProtocol(authorize, nil, true, OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),


### PR DESCRIPTION
This change uprevs omegaup/go-base to v2 to be able to emit logs in JSON
format. #minor