### PR TITLE
Bump quark dependency to v1.6.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/o1egl/paseto v1.0.0
 	github.com/omegaup/githttp v1.4.0
 	github.com/omegaup/go-base/v2 v2.1.0
-	github.com/omegaup/quark v1.6.1
+	github.com/omegaup/quark v1.6.2
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.8.0
 	github.com/saintfish/chardet v0.0.0-20120816061221-3af4cd4741ca

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/omegaup/quark v1.5.4/go.mod h1:tYl8nsttZzuR2Ftxzgz/Hpxd8vkXG3Es8WxWlc
 github.com/omegaup/quark v1.6.0/go.mod h1:5EW7vBSmpqKjXZ1pB0mDkRjqw2BG1TJDoys3ziwe/f8=
 github.com/omegaup/quark v1.6.1 h1:AdzrEFQnYggY4CsAZr9g3JeMlriLJyapqcBFVATDYwE=
 github.com/omegaup/quark v1.6.1/go.mod h1:SYTm75SSGqTyWcbjFUWhUgbRNvg0Qxx45EyvIAKbKnI=
+github.com/omegaup/quark v1.6.2 h1:OyzOiQGrqE5KCGKiLxNfbTMHm3dPUOdnDzAVUAjmw/4=
+github.com/omegaup/quark v1.6.2/go.mod h1:SYTm75SSGqTyWcbjFUWhUgbRNvg0Qxx45EyvIAKbKnI=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=


### PR DESCRIPTION
This change uprevs quark to v1.6.2 to fix a typo in `group_score_policy`.