### PR TITLE
Validate that there is at least one valid case

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -605,6 +605,14 @@ func validateUpdateMaster(
 		return err
 	}
 
+	// Cases.
+	if len(problemSettings.Cases) == 0 {
+		return base.ErrorWithCategory(
+			ErrProblemBadLayout,
+			errors.New("cases/ directory missing or empty"),
+		)
+	}
+
 	// Tests.
 	testsTreeEntry := tree.EntryByName("tests")
 	if testsTreeEntry != nil {


### PR DESCRIPTION
Previously we were accepting malformed .zips that lacked a cases/
directory (or had invalid cases).

Fixes: https://github.com/omegaup/omegaup/issues/6059