### PR TITLE
Add readiness and liveness k8s checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+cmd/omegaup-gitserver/omegaup.db

--- a/cmd/omegaup-gitserver/health_test.go
+++ b/cmd/omegaup-gitserver/health_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/omegaup/gitserver"
+	base "github.com/omegaup/go-base/v2"
+)
+
+var (
+	fakeInteractiveSettingsCompiler = &gitserver.FakeInteractiveSettingsCompiler{
+		Settings: nil,
+		Err:      errors.New("unsupported"),
+	}
+)
+
+func TestHealth(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
+	if os.Getenv("PRESERVE") == "" {
+		defer os.RemoveAll(tmpDir)
+	}
+
+	log := base.StderrLog(false)
+	ts := httptest.NewUnstartedServer(nil)
+	_, portString, err := net.SplitHostPort(ts.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	port, err := strconv.ParseInt(portString, 10, 32)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	config := DefaultConfig()
+	config.Gitserver.Port = uint16(port)
+	authorize, err := createAuthorizationCallback(&config, log)
+	if err != nil {
+		t.Fatalf("authorization callback: %v", err)
+	}
+
+	ts.Config.Handler = muxHandler(
+		nil,
+		config.Gitserver.Port,
+		tmpDir,
+		gitserver.NewGitProtocol(authorize, nil, false, gitserver.OverallWallTimeHardLimit, fakeInteractiveSettingsCompiler, log),
+		log,
+	)
+	ts.Start()
+	defer ts.Close()
+
+	problemAlias := "sumas"
+
+	repo, err := gitserver.InitRepository(path.Join(tmpDir, problemAlias))
+	if err != nil {
+		t.Fatalf("Failed to initialize git repository: %v", err)
+	}
+	defer repo.Free()
+
+	for _, path := range []string{"/health/live", "/health/ready"} {
+		path := path
+		t.Run(path, func(t *testing.T) {
+			res, err := ts.Client().Get(ts.URL + path)
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			defer res.Body.Close()
+
+			if res.StatusCode != 200 {
+				body, _ := io.ReadAll(res.Body)
+				t.Fatalf("health check failure: HTTP %d: %v", res.StatusCode, string(body))
+			}
+		})
+	}
+}

--- a/health.go
+++ b/health.go
@@ -1,0 +1,49 @@
+package gitserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// HealthHandler is an implementation of k8s readiness and liveness checks. The
+// liveness check just returns HTTP 200 (because the server is reachable), but
+// the readiness check tries to interact with the service by requesting the
+// settings.json file of the sumas problem. Getting a 404 is fine.
+func HealthHandler(port uint16) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health/live", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("http://localhost:%d/sumas/+/master/settings.json", port), nil)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(fmt.Sprintf("request: %v", err)))
+			return
+		}
+
+		req.Header.Add("Authorization", "omegaup:health")
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(fmt.Sprintf("request: %v", err)))
+			return
+		}
+		defer res.Body.Close()
+
+		if res.StatusCode != 200 && res.StatusCode != 404 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(fmt.Sprintf("HTTP/%d", res.StatusCode)))
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+	return mux
+}


### PR DESCRIPTION
This should let us keep k8s in a much healthier state and have k8s
restart gitserver if it ever gets into a terrible state where it cannot
do any progress.