### PR TITLE
Add even more tracing

### DIFF
--- a/cmd/omegaup-gitserver/health_test.go
+++ b/cmd/omegaup-gitserver/health_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"io"
 	"io/ioutil"
@@ -31,6 +32,8 @@ func TestHealth(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewUnstartedServer(nil)
@@ -69,7 +72,7 @@ func TestHealth(t *testing.T) {
 
 	problemAlias := "sumas"
 
-	repo, err := gitserver.InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := gitserver.InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}

--- a/cmd/omegaup-translate-problem/main.go
+++ b/cmd/omegaup-translate-problem/main.go
@@ -453,6 +453,7 @@ func createPackfileFromMergedCommit(
 }
 
 func unmergeRepository(
+	ctx context.Context,
 	sourceRepositoryPath,
 	destRepositoryPath string,
 	ignoreCommitter bool,
@@ -468,7 +469,7 @@ func unmergeRepository(
 	}
 	defer sourceRepo.Free()
 
-	destRepo, err := gitserver.InitRepository(destRepositoryPath)
+	destRepo, err := gitserver.InitRepository(ctx, destRepositoryPath)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
@@ -606,6 +607,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx := context.Background()
 	operation := args[0]
 	sourceRepositoryPath := args[1]
 	destRepositoryPath := args[2]
@@ -635,7 +637,7 @@ func main() {
 		}
 		defer f.Close()
 
-		report, err := unmergeRepository(sourceRepositoryPath, destRepositoryPath, *ignoreCommitter, log)
+		report, err := unmergeRepository(ctx, sourceRepositoryPath, destRepositoryPath, *ignoreCommitter, log)
 		if err != nil {
 			log.Crit(
 				"failed to unmerge repository",

--- a/cmd/omegaup-translate-problem/main_test.go
+++ b/cmd/omegaup-translate-problem/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path"
@@ -18,6 +19,7 @@ func TestRoundtrip(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(dirName)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 
@@ -27,7 +29,7 @@ func TestRoundtrip(t *testing.T) {
 	if err := mergeRepository("testdata/sumas.git", mergedPath, log); err != nil {
 		t.Fatalf("failed to merge repository: %v", err)
 	}
-	got, err := unmergeRepository(mergedPath, unmergedPath, false, log)
+	got, err := unmergeRepository(ctx, mergedPath, unmergedPath, false, log)
 	if err != nil {
 		t.Fatalf("failed to unmerge repository: %v", err)
 	}

--- a/cmd/omegaup-update-problem/main.go
+++ b/cmd/omegaup-update-problem/main.go
@@ -330,7 +330,7 @@ func commitBlobs(
 		return nil, err
 	}
 
-	updatedFiles, err := gitserver.GetUpdatedFiles(repo, updatedRefs)
+	updatedFiles, err := gitserver.GetUpdatedFiles(ctx, repo, updatedRefs)
 	if err != nil {
 		log.Error("failed to get updated files", "err", err)
 	}
@@ -358,6 +358,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	ctx := context.Background()
 	var repo *git.Repository
 	commitCallback := func() error { return nil }
 	if _, err := os.Stat(*repositoryPath); os.IsNotExist(err) {
@@ -373,7 +374,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		repo, err = gitserver.InitRepository(dir)
+		repo, err = gitserver.InitRepository(ctx, dir)
 		if err != nil {
 			log.Crit("Failed to init bare repository", "err", err)
 			os.Exit(1)

--- a/cmd/omegaup-update-problem/main_test.go
+++ b/cmd/omegaup-update-problem/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"io"
 	"io/ioutil"
 	"os"
@@ -20,6 +21,8 @@ import (
 )
 
 func getTreeOid(t *testing.T, extraFileContents map[string]io.Reader, log log15.Logger) *git.Oid {
+	t.Helper()
+	ctx := context.Background()
 	tmpdir, err := ioutil.TempDir("", "gitrepo")
 	if err != nil {
 		t.Fatalf("Failed to create tempdir: %v", err)
@@ -45,7 +48,7 @@ func getTreeOid(t *testing.T, extraFileContents map[string]io.Reader, log log15.
 		t.Fatalf("Failed to write zip: %v", err)
 	}
 
-	repo, err := gitserver.InitRepository(tmpdir)
+	repo, err := gitserver.InitRepository(ctx, tmpdir)
 	if err != nil {
 		t.Fatalf("Failed to initialize bare repository: %v", err)
 	}
@@ -202,8 +205,9 @@ func TestProblemUpdateZip(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpdir)
 	}
+	ctx := context.Background()
 
-	repo, err := gitserver.InitRepository(tmpdir)
+	repo, err := gitserver.InitRepository(ctx, tmpdir)
 	if err != nil {
 		t.Fatalf("Failed to initialize bare repository: %v", err)
 	}
@@ -335,8 +339,9 @@ func TestProblemUpdateBlobs(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpdir)
 	}
+	ctx := context.Background()
 
-	repo, err := gitserver.InitRepository(tmpdir)
+	repo, err := gitserver.InitRepository(ctx, tmpdir)
 	if err != nil {
 		t.Fatalf("Failed to initialize bare repository: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/newrelic/go-agent/v3 v3.15.1
 	github.com/o1egl/paseto v1.0.0
-	github.com/omegaup/githttp/v2 v2.2.0
+	github.com/omegaup/githttp/v2 v2.2.1
 	github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211201150123-3ace5d86e12a
 	github.com/omegaup/go-base/v2 v2.3.0
 	github.com/omegaup/quark v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/omegaup/githttp/v2 v2.2.0 h1:KehjPh4s0L9Oj3HG7bMykqa/tZ3hDATpNQ6q9ql9in8=
 github.com/omegaup/githttp/v2 v2.2.0/go.mod h1:QOU20srNzkvDPsJpFbloR9yWrlwCcRW7Q2d9tIW3x/M=
+github.com/omegaup/githttp/v2 v2.2.1 h1:dEpQDSQB7HOGDuX5oh93YqT/f3Be1QsnO+r03P6jopI=
+github.com/omegaup/githttp/v2 v2.2.1/go.mod h1:QOU20srNzkvDPsJpFbloR9yWrlwCcRW7Q2d9tIW3x/M=
 github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211201150123-3ace5d86e12a h1:vORkEPKY98j2/dqacWsrj/4uEM3qecgLMjwPZgBGH04=
 github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211201150123-3ace5d86e12a/go.mod h1:oFTFEE0LxFk4ahZfZe+rV0aPdJbtSiDoTlvrGZXqTyY=
 github.com/omegaup/go-base/v2 v2.3.0 h1:u5juOm0O96ZeuJu3xYSwvyGtstIkCEDT/F016gzSfow=

--- a/handler_test.go
+++ b/handler_test.go
@@ -288,6 +288,7 @@ func TestInvalidRef(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -307,7 +308,7 @@ func TestInvalidRef(t *testing.T) {
 	problemAlias := "sumas"
 
 	{
-		repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+		repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 		if err != nil {
 			t.Fatalf("Failed to initialize git repository: %v", err)
 		}
@@ -366,6 +367,7 @@ func TestDelete(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -385,7 +387,7 @@ func TestDelete(t *testing.T) {
 	problemAlias := "sumas"
 
 	{
-		repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+		repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 		if err != nil {
 			t.Fatalf("Failed to initialize git repository: %v", err)
 		}
@@ -447,6 +449,7 @@ func TestServerCreateReview(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -466,7 +469,7 @@ func TestServerCreateReview(t *testing.T) {
 	problemAlias := "sumas"
 
 	{
-		repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+		repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 		if err != nil {
 			t.Fatalf("Failed to initialize git repository: %v", err)
 		}
@@ -1242,6 +1245,7 @@ func TestPushGitbomb(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -1261,7 +1265,7 @@ func TestPushGitbomb(t *testing.T) {
 	problemAlias := "sumas"
 
 	{
-		repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+		repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 		if err != nil {
 			t.Fatalf("Failed to initialize git repository: %v", err)
 		}
@@ -1365,6 +1369,7 @@ func TestConfig(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -1384,7 +1389,7 @@ func TestConfig(t *testing.T) {
 	problemAlias := "sumas"
 
 	{
-		repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+		repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 		if err != nil {
 			t.Fatalf("Failed to initialize git repository: %v", err)
 		}
@@ -1718,6 +1723,7 @@ func TestInteractive(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -1747,7 +1753,7 @@ func TestInteractive(t *testing.T) {
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -1837,6 +1843,7 @@ int main(int argc, char* argv[]) {
 	defer masterTree.Free()
 
 	problemSettings, err := getProblemSettings(
+		ctx,
 		repo,
 		masterTree,
 	)
@@ -1887,6 +1894,7 @@ func TestExampleCases(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -1906,7 +1914,7 @@ func TestExampleCases(t *testing.T) {
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -2219,6 +2227,7 @@ func TestStatements(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -2238,7 +2247,7 @@ func TestStatements(t *testing.T) {
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -2320,6 +2329,7 @@ func TestTests(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	log := base.StderrLog(false)
 	ts := httptest.NewServer(NewGitHandler(GitHandlerOpts{
@@ -2339,7 +2349,7 @@ func TestTests(t *testing.T) {
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}

--- a/ziphandler_test.go
+++ b/ziphandler_test.go
@@ -2,6 +2,7 @@ package gitserver
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -235,10 +236,11 @@ func TestConvertZip(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -259,6 +261,7 @@ func TestConvertZip(t *testing.T) {
 	commitMessage := "Initial commit"
 
 	zipOid, err := ConvertZipToPackfile(
+		ctx,
 		common.NewProblemFilesFromMap(
 			fileContents,
 			"problem.zip",
@@ -473,10 +476,11 @@ func TestZiphandlerStatements(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -516,6 +520,7 @@ func TestZiphandlerStatements(t *testing.T) {
 			commitMessage := "Initial commit"
 
 			_, err = ConvertZipToPackfile(
+				ctx,
 				common.NewProblemFilesFromMap(
 					testcase.fileContents,
 					"problem.zip",
@@ -556,10 +561,11 @@ func TestTestplan(t *testing.T) {
 	if os.Getenv("PRESERVE") == "" {
 		defer os.RemoveAll(tmpDir)
 	}
+	ctx := context.Background()
 
 	problemAlias := "sumas"
 
-	repo, err := InitRepository(path.Join(tmpDir, problemAlias))
+	repo, err := InitRepository(ctx, path.Join(tmpDir, problemAlias))
 	if err != nil {
 		t.Fatalf("Failed to initialize git repository: %v", err)
 	}
@@ -587,6 +593,7 @@ func TestTestplan(t *testing.T) {
 		commitMessage := "Initial commit"
 
 		_, err = ConvertZipToPackfile(
+			ctx,
 			common.NewProblemFilesFromMap(
 				fileContents,
 				"problem.zip",


### PR DESCRIPTION
Now every function that interacts with git2go should in theory be
traced, both here and in githttp.