### PR TITLE
Add a 2-minute timeout to all requests

### DIFF
--- a/cmd/omegaup-gitserver/main.go
+++ b/cmd/omegaup-gitserver/main.go
@@ -202,15 +202,21 @@ func main() {
 
 	var servers []*http.Server
 	var wg sync.WaitGroup
+	writeTimeout := 2 * time.Minute // Frontend has a 120s second timeout.
 	gitServer := &http.Server{
 		Addr: fmt.Sprintf(":%d", config.Gitserver.Port),
-		Handler: muxHandler(
-			app,
-			config.Gitserver.Port,
-			config.Gitserver.RootPath,
-			protocol,
-			log,
+		Handler: http.TimeoutHandler(
+			muxHandler(
+				app,
+				config.Gitserver.Port,
+				config.Gitserver.RootPath,
+				protocol,
+				log,
+			),
+			writeTimeout,
+			"Timeout",
 		),
+		WriteTimeout: writeTimeout,
 	}
 	servers = append(servers, gitServer)
 	wg.Add(1)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/newrelic/go-agent/v3 v3.15.2
 	github.com/o1egl/paseto v1.0.0
-	github.com/omegaup/githttp/v2 v2.4.0
+	github.com/omegaup/githttp/v2 v2.4.1
 	github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547
 	github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211211212159-014332e01547
 	github.com/omegaup/go-base/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQ
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/omegaup/githttp/v2 v2.4.0 h1:JzofX/w5GcSpT2WSJqQxZB1PwRwn0lguN1qjedM25Gg=
 github.com/omegaup/githttp/v2 v2.4.0/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
+github.com/omegaup/githttp/v2 v2.4.1 h1:8sW2TG1CUi3vbUBcO7FYZEklBQUrORXRaLOc6CC34iQ=
+github.com/omegaup/githttp/v2 v2.4.1/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
 github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547 h1:+SBWLdt2W+OwgpSmpa7AQyfUP7e/vMRtZpxINbYObaY=
 github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547/go.mod h1:adWq3jVZVRlre+15uby0M/AQiAFdpQPYnXiKK90KD4Q=
 github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211211212159-014332e01547 h1:4xRiCayV7L85BMdfEIpW+jJJd6TvphVP/QVh+Mp6rUw=


### PR DESCRIPTION
Upstream has a 2-minute timeout, so we shouldn't try to keep things
alive any longer.