### PR TITLE
Uprev githttp to v2.4.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.8
 	github.com/newrelic/go-agent/v3 v3.15.2
 	github.com/o1egl/paseto v1.0.0
-	github.com/omegaup/githttp/v2 v2.4.4
+	github.com/omegaup/githttp/v2 v2.4.6
 	github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547
 	github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211211212159-014332e01547
 	github.com/omegaup/go-base/v3 v3.2.0

--- a/go.sum
+++ b/go.sum
@@ -224,6 +224,10 @@ github.com/omegaup/githttp/v2 v2.4.1 h1:8sW2TG1CUi3vbUBcO7FYZEklBQUrORXRaLOc6CC3
 github.com/omegaup/githttp/v2 v2.4.1/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
 github.com/omegaup/githttp/v2 v2.4.4 h1:KEQPUSnzwcA1Vkjj5vqtJbWxSOEdr3W8Gw8y3YuOYN0=
 github.com/omegaup/githttp/v2 v2.4.4/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
+github.com/omegaup/githttp/v2 v2.4.5 h1:RslW/X9iRUOBnaMARMm7d9/ZlkYMouRT+OXVXDSTMYg=
+github.com/omegaup/githttp/v2 v2.4.5/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
+github.com/omegaup/githttp/v2 v2.4.6 h1:Jsw3UQvKwIqlkNE3+/AlJjw86k/qQm2cpN8t7dZaMio=
+github.com/omegaup/githttp/v2 v2.4.6/go.mod h1:TQ9YAhkWccbhyLQ6HAYElCgO8qpYqhNlhCnCbOGCMP0=
 github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547 h1:+SBWLdt2W+OwgpSmpa7AQyfUP7e/vMRtZpxINbYObaY=
 github.com/omegaup/go-base/logging/log15 v0.0.0-20211211212159-014332e01547/go.mod h1:adWq3jVZVRlre+15uby0M/AQiAFdpQPYnXiKK90KD4Q=
 github.com/omegaup/go-base/tracing/newrelic v0.0.0-20211211212159-014332e01547 h1:4xRiCayV7L85BMdfEIpW+jJJd6TvphVP/QVh+Mp6rUw=


### PR DESCRIPTION
This change finally allows the grader and gitserver to no longer _need_
to be colocated in the exact same machine.