### PR TITLE
Upload files to S3 after renaming

### DIFF
--- a/cmd/omegaup-gitserver/main.go
+++ b/cmd/omegaup-gitserver/main.go
@@ -91,6 +91,11 @@ func (c *postUpdateCallback) callback(
 	repo *git.Repository,
 	updatedFiles []string,
 ) error {
+	if strings.Contains(repo.Path(), "temp.") {
+		// This is a pre-committed repository. We'll upload it when
+		// we commit it.
+		return nil
+	}
 	for _, updatedFile := range updatedFiles {
 		if !strings.HasPrefix(updatedFile, "refs/heads/") &&
 			!strings.HasPrefix(updatedFile, "objects/pack/pack-") &&

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,7 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/text v0.4.0 h1:BrVqGRd7+k1DiOgtnFvAkoQEWQvBc25ouMJM6429SFg=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
This change now can upload files to S3 after renames happen, so that the files are in the right place.